### PR TITLE
add minimal word length setting

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -66,7 +66,7 @@ class MyApp extends StatelessWidget {
     ]);
 
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Bnoggles',
       theme: ThemeData(primarySwatch: Colors.blue),
       home: StartScreen(dictionary: dictionary, generator: generator),
     );

--- a/lib/screens/game/game_screen.dart
+++ b/lib/screens/game/game_screen.dart
@@ -61,7 +61,7 @@ class GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
           context,
           MaterialPageRoute(
               builder: (context) =>
-                  ResultScreen(gameInfo.solution, userAnswer)));
+                  ResultScreen(gameInfo.board, gameInfo.solution, userAnswer)));
     }
 
     return Scaffold(

--- a/lib/screens/game/game_screen.dart
+++ b/lib/screens/game/game_screen.dart
@@ -57,7 +57,7 @@ class GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
 
       disposeController();
 
-      Navigator.push(
+      Navigator.pushReplacement(
           context,
           MaterialPageRoute(
               builder: (context) =>

--- a/lib/screens/game/game_screen.dart
+++ b/lib/screens/game/game_screen.dart
@@ -69,6 +69,7 @@ class GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
             AppBar(title: Text("Bnoggles"), leading: new Container(), actions: [
           IconButton(
             icon: Icon(Icons.stop),
+            color: Colors.red,
             onPressed: () {
               showResultScreen();
             },

--- a/lib/screens/game/widgets/game_board_grid.dart
+++ b/lib/screens/game/widgets/game_board_grid.dart
@@ -74,7 +74,7 @@ class GridState extends State<Grid> {
         word.write(board.characterAt(position));
       }
 
-      if (word.length >= 2) {
+      if (word.length >= gameInfo.solution.minimalLength) {
         var candidate = word.toString();
 
         UserAnswer old = gameInfo.userAnswer.value;

--- a/lib/screens/game/widgets/game_board_grid.dart
+++ b/lib/screens/game/widgets/game_board_grid.dart
@@ -108,6 +108,8 @@ class GridState extends State<Grid> {
     num padding = cellWidth / 8;
     num textSize = cellWidth / 4;
 
+    CenteredCharacter cc = HittableCenteredCharacter(padding, textSize);
+
     return Container(
         margin: const EdgeInsets.only(left: 4.0, right: 4.0, bottom: 2.0),
         child: Listener(
@@ -138,34 +140,15 @@ class GridState extends State<Grid> {
                         new Border.all(width: 5.0, color: Colors.blueAccent),
                     color: (selected ? Colors.lightBlueAccent : Colors.white),
                   ),
-                  child: Padding(
-                    padding: new EdgeInsets.all(padding),
-                    child: _buildPositionedWidget(
-                        position, character, selected, textSize),
-                  ),
+                  child: cc.create(
+                      position: position,
+                      selected: selected,
+                      character: character),
                 );
               },
             ),
           ),
         ));
-  }
-
-  _PositionedWidget _buildPositionedWidget(
-      Coordinate position, String character, bool selected, num textSize) {
-    return _PositionedWidget(
-      position: position,
-      child: Container(
-        // Without this line the interface is unresponsive. Not sure why.
-        color: selected ? Colors.lightBlueAccent : Colors.white,
-
-        child: Center(
-            child: Text(character.toUpperCase(),
-                style: TextStyle(
-                    fontSize: textSize,
-                    fontWeight: FontWeight.bold,
-                    color: (selected ? Colors.white : Colors.black)))),
-      ),
-    );
   }
 }
 
@@ -189,4 +172,51 @@ class _PositionedWidget extends SingleChildRenderObjectWidget {
 
 class _PositionedRenderObject extends RenderProxyBox {
   Coordinate position;
+}
+
+class CenteredCharacter {
+  final double textSize;
+
+  CenteredCharacter(this.textSize);
+
+  Widget create({
+    Coordinate position,
+    String character,
+    bool selected,
+  }) {
+    return Center(
+        child: Text(character.toUpperCase(),
+            style: TextStyle(
+                fontSize: textSize,
+                fontWeight: FontWeight.bold,
+                color: (selected ? Colors.white : Colors.black))));
+  }
+}
+
+class HittableCenteredCharacter extends CenteredCharacter {
+  final double padding;
+
+  HittableCenteredCharacter(this.padding, textSize) : super(textSize);
+
+  Widget create({
+    Coordinate position,
+    String character,
+    bool selected,
+  }) {
+    Widget child = super
+        .create(position: position, character: character, selected: selected);
+
+    return Padding(
+      padding: new EdgeInsets.all(padding),
+      child: _PositionedWidget(
+        position: position,
+        child: Container(
+          // Without this line the interface is unresponsive. Not sure why.
+          color: selected ? Colors.lightBlueAccent : Colors.white,
+
+          child: child,
+        ),
+      ),
+    );
+  }
 }

--- a/lib/screens/game/widgets/game_board_grid.dart
+++ b/lib/screens/game/widgets/game_board_grid.dart
@@ -96,20 +96,12 @@ class GridState extends State<Grid> {
   @override
   Widget build(BuildContext context) {
     Board board = Provider.of(context).board;
-    int width = board.width;
 
     num mediaWidth = MediaQuery.of(context).size.width;
-    num cellWidth = mediaWidth / width;
+    num cellWidth = mediaWidth / board.width;
     num padding = cellWidth / 8;
     num textSize = cellWidth / 4;
 
-    CenteredCharacter cc = HittableCenteredCharacter(padding, textSize);
-
-    return buildContainer(board, cc);
-  }
-
-  Container buildContainer(Board board, CenteredCharacter cc) {
-    int width = board.width;
     return Container(
         key: _key,
         margin: const EdgeInsets.only(left: 4.0, right: 4.0, bottom: 2.0),
@@ -120,7 +112,7 @@ class GridState extends State<Grid> {
           child: Container(
             child: BoardWidget(
               board: board,
-              centeredCharacter: cc,
+              centeredCharacter: HittableCenteredCharacter(padding, textSize),
               selectedPositions: _selectedPositions,
             ),
           ),

--- a/lib/screens/game/widgets/game_word_count_row.dart
+++ b/lib/screens/game/widgets/game_word_count_row.dart
@@ -31,7 +31,7 @@ class WordCountOverview extends StatelessWidget {
     );
   }
 
-  Widget fromIndex(int index, Answer solution) {
+  Widget fromIndex(int index, Solution solution) {
     int rowSize = (_maxLength - 1);
     int lastIndexRow1 = rowSize - 1;
 
@@ -44,7 +44,9 @@ class WordCountOverview extends StatelessWidget {
       }
       return NumberInfo(text);
     }
-
+    if (length < solution.minimalLength) {
+      return NoNumberInfo();
+    }
     return UserAnswerNumberInfo(length);
   }
 }
@@ -61,6 +63,21 @@ class NumberInfo extends StatelessWidget {
     );
   }
 }
+
+
+class NoNumberInfo extends StatelessWidget {
+  NoNumberInfo();
+
+  @override
+  build(BuildContext context) {
+    return Container(
+      color: Colors.blueGrey,
+      child: Center(child: Text('x', style: TextStyle(color: Colors.white70))),
+    );
+  }
+}
+
+
 
 class UserAnswerNumberInfo extends StatelessWidget {
   final int length;

--- a/lib/screens/result/result_screen.dart
+++ b/lib/screens/result/result_screen.dart
@@ -49,36 +49,36 @@ class ResultScreen extends StatelessWidget {
                   BoxDecoration(border: Border.all(color: Colors.black)),
               width: 150.0,
               child: ListView(children: divided)),
-          Expanded(child: Container()),
-          Column(children: [
-            Center(
-                child: Container(
-                    child: Text(
-              "$score",
-              style: TextStyle(fontSize: 100.0),
-            ))),
-            Container(
-              width: 300.0,
-                child: BoardWidget(
-              selectedPositions: [],
-              board: board,
-              centeredCharacter: CenteredCharacter(20.0),
-            )),
-            FloatingActionButton(
-              onPressed: () {
-                Navigator.popUntil(
-                    context, ModalRoute.withName(Navigator.defaultRouteName));
-              },
-              child: Icon(Icons.home),
-            ),
-          ]),
-          Expanded(child: Container()),
+          Expanded(
+            child: Column(children: [
+              Center(
+                  child: Container(
+                      child: Text(
+                "$score",
+                style: TextStyle(fontSize: 100.0),
+              ))),
+              Container(
+                  margin: const EdgeInsets.all(10.0),
+                  child: BoardWidget(
+                    selectedPositions: [],
+                    board: board,
+                    centeredCharacter: CenteredCharacter(20.0),
+                  )),
+              FloatingActionButton(
+                onPressed: () {
+                  Navigator.popUntil(
+                      context, ModalRoute.withName(Navigator.defaultRouteName));
+                },
+                child: Icon(Icons.home),
+              ),
+            ]),
+          ),
         ]),
       ),
     );
   }
 
-  int calculateScore(Solution solution, UserAnswer userAnswer) {
+  int calculateScore(Solution solution, Answer userAnswer) {
     int result = 0;
     for (String word in userAnswer.uniqueWords()) {
       result += word.length * 2;

--- a/lib/screens/result/result_screen.dart
+++ b/lib/screens/result/result_screen.dart
@@ -14,6 +14,7 @@ class ResultScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     int score = calculateScore(solution, userAnswer);
+    int maxScore = calculateScore(solution, solution);
 
     var tiles = solution.uniqueWordsSorted().map((w) {
       return ListTile(
@@ -54,7 +55,7 @@ class ResultScreen extends StatelessWidget {
               Center(
                   child: Container(
                       child: Text(
-                "$score",
+                "$score / $maxScore",
                 style: TextStyle(fontSize: 100.0),
               ))),
               Container(

--- a/lib/screens/result/result_screen.dart
+++ b/lib/screens/result/result_screen.dart
@@ -37,7 +37,6 @@ class ResultScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        leading: new Container(),
         title: Text("Bnoggles"),
       ),
       body: Center(

--- a/lib/screens/result/result_screen.dart
+++ b/lib/screens/result/result_screen.dart
@@ -1,12 +1,15 @@
+import 'package:bnoggles/utils/board.dart';
+import 'package:bnoggles/widgets/board_widget.dart';
 import 'package:flutter/material.dart';
 
 import 'package:bnoggles/utils/solution.dart';
 
 class ResultScreen extends StatelessWidget {
+  final Board board;
   final Solution solution;
   final UserAnswer userAnswer;
 
-  ResultScreen(this.solution, this.userAnswer);
+  ResultScreen(this.board, this.solution, this.userAnswer);
 
   @override
   Widget build(BuildContext context) {
@@ -54,6 +57,13 @@ class ResultScreen extends StatelessWidget {
               "$score",
               style: TextStyle(fontSize: 100.0),
             ))),
+            Container(
+              width: 300.0,
+                child: BoardWidget(
+              selectedPositions: [],
+              board: board,
+              centeredCharacter: CenteredCharacter(20.0),
+            )),
             FloatingActionButton(
               onPressed: () {
                 Navigator.popUntil(

--- a/lib/screens/start/start_screen.dart
+++ b/lib/screens/start/start_screen.dart
@@ -24,15 +24,19 @@ class StartScreenState extends State<StartScreen> {
 
   ValueNotifier<int> time = ValueNotifier(150);
   ValueNotifier<int> size = ValueNotifier(3);
+  ValueNotifier<int> length = ValueNotifier(2);
 
   StartScreenState({@required this.generator, @required this.dictionary});
 
-    setBoardWidth(int value) {
+  setBoardWidth(int value) {
     size.value = value;
   }
 
   setTime(int value) {
     time.value = value;
+  }
+  setLength(int value) {
+    length.value = value;
   }
 
   @override
@@ -47,12 +51,12 @@ class StartScreenState extends State<StartScreen> {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            SettingsGrid(time, size),
+            SettingsGrid(time, size, length),
             Center(
               child: FloatingActionButton(
                 onPressed: () {
                   var board = Board(size.value, generator);
-                  var solution = Solution(board, dictionary);
+                  var solution = Solution(board, dictionary, length.value);
 
                   Navigator.push(
                     context,

--- a/lib/screens/start/widgets/length_slider.dart
+++ b/lib/screens/start/widgets/length_slider.dart
@@ -1,0 +1,69 @@
+import 'package:bnoggles/screens/start/start_screen.dart';
+import 'package:flutter/material.dart';
+
+class LengthIcon extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Icon(Icons.text_rotation_none, size: 40.0,);
+  }
+}
+
+class LengthText extends StatefulWidget {
+  final ValueNotifier<int> length;
+  LengthText({Key key, this.length}) : super(key: key);
+
+  @override
+  LengthTextState createState() => LengthTextState();
+}
+
+class LengthTextState extends State<LengthText> {
+  @override
+  void initState() {
+    super.initState();
+    widget.length.addListener(didValueChange);
+  }
+
+  void didValueChange() => setState(() {});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('${widget.length.value}+',
+        style: TextStyle(fontSize: 20.0));
+  }
+}
+
+class LengthSlider extends StatefulWidget {
+  @override
+  _LengthSliderState createState() => _LengthSliderState();
+}
+
+class _LengthSliderState extends State<LengthSlider> {
+  static const int _startSize = 2;
+
+  double _value = _startSize + .0;
+
+  void _onChanged(double value) {
+    setState(() {
+      _value = value;
+    });
+  }
+
+  void _onChangedEnd(double value, BuildContext context) {
+    StartScreenState startScreen =
+        context.ancestorStateOfType(const TypeMatcher<StartScreenState>());
+    startScreen.setLength(value.floor());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Slider(
+      value: _value,
+      min: 2.0,
+      max: 4.0,
+      divisions: 2,
+      label: '${_value.floor()}+',
+      onChanged: _onChanged,
+      onChangeEnd: (double value) => _onChangedEnd(value, context),
+    );
+  }
+}

--- a/lib/screens/start/widgets/settings.dart
+++ b/lib/screens/start/widgets/settings.dart
@@ -1,4 +1,5 @@
 import 'package:bnoggles/screens/start/widgets/board_size_slider.dart';
+import 'package:bnoggles/screens/start/widgets/length_slider.dart';
 import 'package:bnoggles/screens/start/widgets/time_slider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -12,8 +13,9 @@ const int _maxLength = 8;
 class SettingsGrid extends StatelessWidget {
   final ValueNotifier<int> _time;
   final ValueNotifier<int> _size;
+  final ValueNotifier<int> _length;
 
-  SettingsGrid(this._time, this._size);
+  SettingsGrid(this._time, this._size, this._length);
 
   @override
   Widget build(BuildContext context) {
@@ -48,6 +50,20 @@ class SettingsGrid extends StatelessWidget {
                 TableCell(child: BoardIcon()),
                 TableCell(child: BoardText(size: _size)),
                 TableCell(child: BoardSizeSlider()),
+              ],
+            ),
+            TableRow(
+              children: [
+                Container(height: 50.0),
+                Container(),
+                Container(),
+              ],
+            ),
+            TableRow(
+              children: [
+                TableCell(child: LengthIcon()),
+                TableCell(child: LengthText(length: _length)),
+                TableCell(child: LengthSlider()),
               ],
             ),
             TableRow(

--- a/lib/utils/solution.dart
+++ b/lib/utils/solution.dart
@@ -60,12 +60,13 @@ class UserAnswer extends Answer {
 
 class Solution extends Answer {
   final Set<Chain> _words;
+  final int minimalLength;
 
-  factory Solution(Board board, Dictionary dict) {
-    return Solution._internal(_Problem(board, dict).find());
+  factory Solution(Board board, Dictionary dict, int minimalLength) {
+    return Solution._internal(_Problem(board, dict, minimalLength).find(), minimalLength);
   }
 
-  Solution._internal(this._words);
+  Solution._internal(this._words, this.minimalLength);
 
   Set<String> uniqueWords() => _words.map((e) => e.text).toSet();
 
@@ -83,16 +84,17 @@ class Solution extends Answer {
 class _Problem {
   final Board board;
   final Dictionary dict;
+  final int minimalLength;
   final Map neighbours;
 
   Queue<Chain> candidates;
   Set<Chain> words;
 
-  factory _Problem(Board board, Dictionary dict) {
-    return _Problem._internal(board, dict, board.mapNeighbours());
+  factory _Problem(Board board, Dictionary dict, int minimalLength) {
+    return _Problem._internal(board, dict, minimalLength, board.mapNeighbours());
   }
 
-  _Problem._internal(this.board, this.dict, this.neighbours);
+  _Problem._internal(this.board, this.dict, this.minimalLength, this.neighbours);
 
   Set<Chain> find() {
     initialCandidates();
@@ -125,7 +127,7 @@ class _Problem {
       var nextCandidate = Chain._extend(baseCandidate, coordinate, word);
       candidates.add(nextCandidate);
 
-      if (info.found) {
+      if (info.found && word.length >= minimalLength) {
         words.add(nextCandidate);
       }
     }

--- a/lib/widgets/board_widget.dart
+++ b/lib/widgets/board_widget.dart
@@ -1,0 +1,76 @@
+import 'package:bnoggles/utils/board.dart';
+import 'package:bnoggles/utils/coordinate.dart';
+import 'package:flutter/material.dart';
+
+class BoardWidget extends StatelessWidget {
+  final List<Coordinate> selectedPositions;
+  final Board board;
+  final CenteredCharacter centeredCharacter;
+
+  const BoardWidget(
+      {Key key,
+      this.selectedPositions,
+      this.board,
+      this.centeredCharacter})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    int width = board.width;
+
+    return GridView.builder(
+      shrinkWrap: true,
+      itemCount: (width * width),
+      physics: NeverScrollableScrollPhysics(),
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: width,
+        childAspectRatio: 1.0,
+        crossAxisSpacing: 5.0,
+        mainAxisSpacing: 5.0,
+      ),
+      itemBuilder: (context, index) {
+        var xy = _indexToXY(index, width);
+        Coordinate position = Coordinate(xy[0], xy[1]);
+        bool selected = selectedPositions.contains(position);
+        String character = board.characterAt(position);
+        return Container(
+          decoration: new BoxDecoration(
+            borderRadius: BorderRadius.all(Radius.circular(10.0)),
+            border: new Border.all(width: 5.0, color: Colors.blueAccent),
+            color: (selected ? Colors.lightBlueAccent : Colors.white),
+          ),
+          child: centeredCharacter.create(
+            selected: selected,
+            character: character,
+            position: position,
+          ),
+        );
+      },
+    );
+  }
+
+  static _indexToXY(int index, int width) {
+    int y = (index / width).floor();
+    int x = index - (y * width).floor();
+    return [x, y];
+  }
+}
+
+class CenteredCharacter {
+  final double textSize;
+
+  CenteredCharacter(this.textSize);
+
+  Widget create({
+    String character,
+    bool selected,
+    Coordinate position,
+  }) {
+    return Center(
+        child: Text(character.toUpperCase(),
+            style: TextStyle(
+                fontSize: textSize,
+                fontWeight: FontWeight.bold,
+                color: (selected ? Colors.white : Colors.black))));
+  }
+}

--- a/test/utils/solution_test.dart
+++ b/test/utils/solution_test.dart
@@ -95,5 +95,5 @@ Solution createSolution() {
 
   Dictionary dict = Dictionary(['ab', 'bc', 'dab', 'xyz']);
 
-  return Solution(mockBoard, dict);
+  return Solution(mockBoard, dict, 2);
 }

--- a/tools/clean_dict_file.dart
+++ b/tools/clean_dict_file.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 const String allowedChars = "abcdefghijklmnopqrstuvwxyz";

--- a/tools/sandbox.dart
+++ b/tools/sandbox.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 main(List<String> arguments) {


### PR DESCRIPTION
Adds a new setting to the setup screen to select the minimal word length.

Shorter words entered by the user will not be checked. The grid above the board displays a white 'x' instead of the number and the results page will not display shorter words.

Current possible values as '2+', '3+' and '4+'.