### PR TITLE
better back button support

### DIFF
--- a/lib/screens/game/game_screen.dart
+++ b/lib/screens/game/game_screen.dart
@@ -57,7 +57,7 @@ class GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
 
       disposeController();
 
-      Navigator.push(
+      Navigator.pushReplacement(
           context,
           MaterialPageRoute(
               builder: (context) =>

--- a/lib/screens/result/result_screen.dart
+++ b/lib/screens/result/result_screen.dart
@@ -37,7 +37,6 @@ class ResultScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        leading: new Container(),
         title: Text("Bnoggles"),
       ),
       body: Center(


### PR DESCRIPTION
In the previous implementation, the back arrow was no longer part of the navigation bar of the results screen. However, the android back button would go back to the game screen.

By using pushReplace, the game screen is removed from the navigation history. 