### PR TITLE
remove indent from appbar

### DIFF
--- a/lib/screens/game/game_screen.dart
+++ b/lib/screens/game/game_screen.dart
@@ -62,7 +62,7 @@ class GameScreenState extends State<GameScreen> with TickerProviderStateMixin {
     return Scaffold(
       appBar: AppBar(
         title: Text("Bnoggles"),
-        leading: new Container(),
+        automaticallyImplyLeading: false,
         actions: [
           IconButton(
             icon: Icon(Icons.stop),

--- a/lib/screens/result/result_screen.dart
+++ b/lib/screens/result/result_screen.dart
@@ -73,7 +73,7 @@ class ResultScreenState extends State<ResultScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text("Bnoggles"),
-        leading: new Container(),
+        automaticallyImplyLeading: false,
       ),
       body: Center(
         child: Row(crossAxisAlignment: CrossAxisAlignment.start, children: [


### PR DESCRIPTION
After reading the documentation of AppBar, I realized we were doing it wrong. 